### PR TITLE
Updates location of PCANBasic dll file

### DIFF
--- a/pcan/PCANBasic.py
+++ b/pcan/PCANBasic.py
@@ -372,7 +372,7 @@ class PCANBasic:
         # Loads the PCANBasic.dll
         #
         if platform.system() == 'Windows':
-            self.__m_dllBasic = windll.LoadLibrary("./pcan/PCANBasic")
+            self.__m_dllBasic = windll.LoadLibrary("PCANBasic")
         else:
             self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
         if self.__m_dllBasic == None:


### PR DESCRIPTION
PCANBasic.dll  can not be loaded. The file is not in directory "pcan" when the package is installed with pip.